### PR TITLE
Upgrade buffer dependency to 6.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "webpack": "^1.15.0"
   },
   "dependencies": {
-    "buffer": "4.9.2",
+    "buffer": "6.0.3",
     "events": "1.1.1",
     "ieee754": "1.1.13",
     "jmespath": "0.16.0",


### PR DESCRIPTION
Using 4.9.2 version of the buffer package package causes an error on Lambda

Since it's a console.error, this logs to AWS CloudWatch every time a request is made.  This problem exists only on Lambda, on local, it doesn't show any such errors.

ERROR    (node:8) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.

![Screenshot 2023-03-10 at 1 41 43 AM](https://user-images.githubusercontent.com/800668/224144296-5e06c079-bfd3-4c81-b77e-a2b98b620434.png)

![Screenshot 2023-03-10 at 1 40 08 AM](https://user-images.githubusercontent.com/800668/224144308-0156cf3d-0171-4099-8c82-66e510eafe5e.png)

![Screenshot 2023-03-10 at 1 39 56 AM](https://user-images.githubusercontent.com/800668/224144310-5d6c1148-9d22-4c9e-80fe-e12286806cad.png)
